### PR TITLE
Forbid copies of LdObject

### DIFF
--- a/src/Leddar/LdObject.h
+++ b/src/Leddar/LdObject.h
@@ -47,6 +47,9 @@ namespace LeddarCore
         void EmitSignal( const SIGNALS aSignal, void *aExtraData = nullptr );
 
     private:
+		LdObject(const LdObject &aObj);
+		LdObject& operator=(const LdObject &aObj);
+
         void DisconnectAll( void );
 
         std::list< LdObject * > mConnectedObject;


### PR DESCRIPTION
Again I don't have the equipment for testing but I strongly suspect that
copying a LdObject instance would mess up the connections between
objects since the internal connected object and receiver members are not
being updated to include the LdObject instance created by the copy.