### PR TITLE
Fix warnings when compiled with max warnings

### DIFF
--- a/src/Leddar/LdDoubleBuffer.cpp
+++ b/src/Leddar/LdDoubleBuffer.cpp
@@ -31,10 +31,12 @@ using namespace LeddarConnection;
 ///
 /// \since   January 2018
 /// *****************************************************************************
-LdDoubleBuffer::LdDoubleBuffer() : mTimestamp( nullptr ), mGetBuffer( new DataBuffer ), mSetBuffer( new DataBuffer ),
-    mFrameId( LeddarCore::LdProperty::CAT_INFO, LeddarCore::LdProperty::F_SAVE, LeddarCore::LdPropertyIds::ID_RS_FRAME_ID, LtComLeddarTechPublic::LT_COMM_ID_FRAME_ID,
+LdDoubleBuffer::LdDoubleBuffer() : mFrameId( LeddarCore::LdProperty::CAT_INFO, LeddarCore::LdProperty::F_SAVE, LeddarCore::LdPropertyIds::ID_RS_FRAME_ID, LtComLeddarTechPublic::LT_COMM_ID_FRAME_ID,
               sizeof( uint64_t ), "Frame id" )
 {
+    mTimestamp = nullptr;
+    mGetBuffer = new DataBuffer();
+    mSetBuffer = new DataBuffer();
     mFrameId.SetCount( 2 );
     mFrameId.ForceValue( 0, 0 );
     mFrameId.ForceValue( 1, 0 );
@@ -250,7 +252,7 @@ void LdDoubleBuffer::SetTimestamp64( uint64_t aTimestamp )
 ///
 /// \returns    The frame identifier.
 ///
-/// \author David Lévy
+/// \author David Lï¿½vy
 /// \date   January 2020
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 uint64_t LeddarConnection::LdDoubleBuffer::GetFrameId( eBuffer aBuffer ) const
@@ -272,7 +274,7 @@ uint64_t LeddarConnection::LdDoubleBuffer::GetFrameId( eBuffer aBuffer ) const
 ///
 /// \param  aFrameId    Identifier for the frame.
 ///
-/// \author David Lévy
+/// \author David Lï¿½vy
 /// \date   January 2020
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void LeddarConnection::LdDoubleBuffer::SetFrameId( uint64_t aFrameId )

--- a/src/Leddar/LdEthernet.cpp
+++ b/src/Leddar/LdEthernet.cpp
@@ -393,13 +393,13 @@ LeddarConnection::LdEthernet::Receive( uint8_t *aBuffer, uint32_t aSize )
         }
     }
 
-    if( lBytesReceived < aSize )
+    if( lBytesReceived < static_cast<int32_t>(aSize) )
     {
         //Retry once to get all expected data
         int32_t lBytesReceived2 = recv( mSocket, ( char * )( aBuffer + lBytesReceived ), aSize, MSG_WAITALL );
         lBytesReceived += lBytesReceived2;
 
-        if( lBytesReceived < aSize )
+        if( lBytesReceived < static_cast<int32_t>(aSize) )
         {
             throw LeddarException::LtComException( "Incomplete data received.", LeddarException::ERROR_COM_READ, false );
         }
@@ -1028,12 +1028,9 @@ LeddarConnection::LdEthernet::ReceiveFrom( std::string &aIpAddress, uint16_t &aP
 {
     sockaddr_in lAddress;
     socklen_t lAddressSize = sizeof( lAddress );
-    int lErr = 0;
 
     const int32_t lResult = recvfrom( mUDPSocket, ( char * )aData, aSize, 0, ( sockaddr * )&lAddress, &lAddressSize );
 
-    if( lResult < 0 )
-        lErr = LAST_ERROR;
 
 #ifdef WIN32
     aIpAddress = LeddarUtils::LtStringUtils::Ip4AddrToString( lAddress.sin_addr.S_un.S_addr );

--- a/src/Leddar/LdPropertiesContainer.cpp
+++ b/src/Leddar/LdPropertiesContainer.cpp
@@ -558,8 +558,6 @@ LeddarCore::LdPropertiesContainer::AddPropertiesFromFile( std::string aFilename 
         throw std::runtime_error( "JSON format error, no element properties." );
     }
 
-    const rapidjson::Value &lPropertiesDescription = lDocument["properties"];
-
     const rapidjson::GenericArray<false, rapidjson::Value::ValueType> lPropArray = lDocument["properties"].GetArray();
 
 

--- a/src/Leddar/LdSensorPixell.cpp
+++ b/src/Leddar/LdSensorPixell.cpp
@@ -194,10 +194,6 @@ void LeddarDevice::LdSensorPixell::GetCalib( void )
         lSensorOrderTimeBaseDelays[i] = lTimeBaseDelays->Value( i );
     }
 
-
-    uint32_t lChannelCount = mProperties->GetIntegerProperty( LdPropertyIds::ID_VSEGMENT )->ValueT<uint16_t>() * mProperties->GetIntegerProperty(
-                                 LdPropertyIds::ID_HSEGMENT )->ValueT<uint16_t>();
-
     for( uint32_t i = 0; i < lTimeBaseDelays->Count(); ++i )
     {
         lTimeBaseDelays->SetValue( SensorChannelIndexToEchoChannelIndex( i ), lSensorOrderTimeBaseDelays[i] );


### PR DESCRIPTION
Those changes are required when building through apollo

Apollo builds using
"-Wall -Werror=sign-compare -Werror=unused-variable -Werror=unused-but-set-variable -Werror=switch -Werror=reorder"